### PR TITLE
Fixed typo & capital letter in Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ This tool can also be further configured with the following command line flags.
 ## Notes
  - Be patient the crawling and screenshot process are very cpu intensive
  - The first site passed to the command defines the internal page paths for all of the other sites
- - Any Sites Larger than (600 pages +) will fail (Don't try an crawl google :$)
+ - Any sites larger than (600 pages +) will fail (Don't try and crawl google :$)
 
 ## Coming soon!
  - Usage with docker


### PR DESCRIPTION
Fixed a typo and changed 'Sites' to 'sites' 😉 